### PR TITLE
Added no cutout for notch devices!!!! Inspired by MIUI and Essential

### DIFF
--- a/core/java/android/app/IActivityManager.aidl
+++ b/core/java/android/app/IActivityManager.aidl
@@ -698,4 +698,9 @@ interface IActivityManager {
      *  Should disable touch if three fingers to screen shot is active?
      */
     boolean isSwipeToScreenshotGestureActive();
+    
+    /**
+     *  Force full screen for devices with cutout
+     */
+    boolean shouldForceCutoutFullscreen(in String packageName);
 }

--- a/core/java/android/hardware/display/AmbientDisplayConfiguration.java
+++ b/core/java/android/hardware/display/AmbientDisplayConfiguration.java
@@ -295,7 +295,7 @@ public class AmbientDisplayConfiguration {
         final boolean ambientLightsEnabled = boolSettingSystem(Settings.System.AOD_NOTIFICATION_PULSE, user, 0);
         if (ambientLightsEnabled) {
             boolean ambientLightsActivated = boolSettingSystem(Settings.System.AOD_NOTIFICATION_PULSE_ACTIVATED, user, 0);
-            return ambientLightsActivated && !accessibilityInversionEnabled(user) && alwaysOnAvailable() && alwaysOnEnabledSetting(user);
+            return ambientLightsActivated && !accessibilityInversionEnabled(user) && alwaysOnAvailable();
         }
         return false;
     }

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5153,7 +5153,7 @@ public final class Settings {
          * @hide
          */
          public static final String NETWORK_TRAFFIC_VIEW_LOCATION = "network_traffic_view_location";
-
+         
 	/**
          * Network traffic font style
          * @hide
@@ -5404,6 +5404,12 @@ public final class Settings {
          */
         public static final String SHOW_FPS_OVERLAY = "show_fps_overlay";
 
+        /**
+         * Force full screen for devices with cutout
+         * @hide
+         */
+        public static final String FORCE_FULLSCREEN_CUTOUT_APPS = "force_full_screen_cutout_apps";
+        
         /**
          * Gaming mode master switch
          * @hide
@@ -6516,6 +6522,7 @@ public final class Settings {
             PRIVATE_SETTINGS.add(LOCKSCREEN_WEATHER_SHOW_TEMP);
             PRIVATE_SETTINGS.add(LOCKSCREEN_WEATHER_SHOW_CITY);
 	    PRIVATE_SETTINGS.add(LOCKSCREEN_WEATHER_SHOW_IMAGE);
+	    PRIVATE_SETTINGS.add(FORCE_FULLSCREEN_CUTOUT_APPS);
             PRIVATE_SETTINGS.add(SCREENSHOT_TYPE);
             PRIVATE_SETTINGS.add(SHOW_VOLTE_ICON);
             PRIVATE_SETTINGS.add(VOLTE_ICON_STYLE);

--- a/core/java/com/android/internal/policy/PhoneWindow.java
+++ b/core/java/com/android/internal/policy/PhoneWindow.java
@@ -31,6 +31,7 @@ import static android.view.WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATIO
 import static android.view.WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
 import static android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
 import static android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT;
+import static android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
 import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_FORCE_DRAW_BAR_BACKGROUNDS;
 
 import android.annotation.NonNull;
@@ -2400,14 +2401,17 @@ public class PhoneWindow extends Window implements MenuBuilder.Callback {
             requestFeature(FEATURE_ACTION_MODE_OVERLAY);
         }
 
+        boolean isFullscreen = false;
         if (a.getBoolean(R.styleable.Window_windowFullscreen, false)) {
             setFlags(FLAG_FULLSCREEN, FLAG_FULLSCREEN & (~getForcedWindowFlags()));
+            isFullscreen = true;
         }
 
         if (a.getBoolean(R.styleable.Window_windowTranslucentStatus,
                 false)) {
             setFlags(FLAG_TRANSLUCENT_STATUS, FLAG_TRANSLUCENT_STATUS
                     & (~getForcedWindowFlags()));
+            isFullscreen = true;
         }
 
         if (a.getBoolean(R.styleable.Window_windowTranslucentNavigation,
@@ -2512,6 +2516,16 @@ public class PhoneWindow extends Window implements MenuBuilder.Callback {
             params.layoutInDisplayCutoutMode = mode;
         }
 
+        if (ActivityManager.isSystemReady() && isFullscreen) {
+            try {
+                String packageName = context.getBasePackageName();
+                if (ActivityManager.getService().shouldForceCutoutFullscreen(packageName)){
+                    params.layoutInDisplayCutoutMode = LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+                }
+            } catch (RemoteException e) {
+            }
+        }
+        
         if (mAlwaysReadCloseOnTouchAttr || getContext().getApplicationInfo().targetSdkVersion
                 >= android.os.Build.VERSION_CODES.HONEYCOMB) {
             if (a.getBoolean(

--- a/core/java/com/android/internal/util/custom/cutout/CutoutFullscreenController.java
+++ b/core/java/com/android/internal/util/custom/cutout/CutoutFullscreenController.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2018 The LineageOS project
+ * Copyright (C) 2019 The PixelExperience project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.util.custom.cutout;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.Resources;
+import android.database.ContentObserver;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.UserHandle;
+import android.text.TextUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+
+import android.provider.Settings;
+
+public class CutoutFullscreenController {
+    private Set<String> mApps = new HashSet<>();
+    private Context mContext;
+
+    private final boolean isAvailable;
+
+    public CutoutFullscreenController(Context context) {
+        mContext = context;
+        final Resources resources = mContext.getResources();
+
+	final String displayCutout = resources.getString(com.android.internal.R.string.config_mainBuiltInDisplayCutout);
+        isAvailable = !TextUtils.isEmpty(displayCutout);
+
+        if (!isAvailable) {
+            return;
+        }
+
+        SettingsObserver observer = new SettingsObserver(
+                new Handler(Looper.getMainLooper()));
+        observer.observe();
+    }
+
+    public boolean isSupported() {
+        return isAvailable;
+    }
+
+    public boolean shouldForceCutoutFullscreen(String packageName) {
+        return isSupported() && mApps.contains(packageName);
+    }
+
+    public Set<String> getApps() {
+        return mApps;
+    }
+
+    public void addApp(String packageName) {
+        mApps.add(packageName);
+        Settings.System.putString(mContext.getContentResolver(),
+                Settings.System.FORCE_FULLSCREEN_CUTOUT_APPS, String.join(",", mApps));
+    }
+
+    public void removeApp(String packageName) {
+        mApps.remove(packageName);
+        Settings.System.putString(mContext.getContentResolver(),
+                Settings.System.FORCE_FULLSCREEN_CUTOUT_APPS, String.join(",", mApps));
+    }
+
+    public void setApps(Set<String> apps) {
+        mApps = apps;
+    }
+
+    class SettingsObserver extends ContentObserver {
+        SettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        void observe() {
+            ContentResolver resolver = mContext.getContentResolver();
+
+            resolver.registerContentObserver(Settings.System.getUriFor(
+                    Settings.System.FORCE_FULLSCREEN_CUTOUT_APPS), false, this,
+                    UserHandle.USER_ALL);
+
+            update();
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            update();
+        }
+
+        public void update() {
+            ContentResolver resolver = mContext.getContentResolver();
+
+            String apps = Settings.System.getStringForUser(resolver,
+                    Settings.System.FORCE_FULLSCREEN_CUTOUT_APPS,
+                    UserHandle.USER_CURRENT);
+            if (apps != null) {
+                setApps(new HashSet<>(Arrays.asList(apps.split(","))));
+            } else {
+                setApps(new HashSet<>());
+            }
+        }
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelViewController.java
@@ -3076,8 +3076,6 @@ public class NotificationPanelViewController extends PanelViewController {
                 Settings.System.NOTIFICATION_PULSE, 0, UserHandle.USER_CURRENT) != 0;
         boolean ambientLights = Settings.System.getIntForUser(resolver,
                 Settings.System.AOD_NOTIFICATION_PULSE, 0, UserHandle.USER_CURRENT) != 0;
-        boolean aodEnabled = Settings.Secure.getIntForUser(resolver,
-                Settings.Secure.DOZE_ALWAYS_ON, 0, UserHandle.USER_CURRENT) == 1;
         ExpandableNotificationRow row = mNotificationStackScroller.getFirstActiveClearableNotifications(ROWS_HIGH_PRIORITY);
         boolean activeNotif = row != null;
         int pulseReason = Settings.System.getIntForUser(resolver,
@@ -3133,7 +3131,7 @@ public class NotificationPanelViewController extends PanelViewController {
                         // but we dont want them here
                         mPulseLightsView.setVisibility(View.GONE);
                     }
-                    if (ambientLights && aodEnabled) {
+                    if (ambientLights) {
                         mPulseLightHandled = false;
                         // tell power manager that we want to enable aod
                         // must do that here already not on pulsing = false
@@ -3146,7 +3144,7 @@ public class NotificationPanelViewController extends PanelViewController {
                 }
             } else {
                 // continue to pulse - if not screen was turned on in the meantime
-                if (activeNotif && ambientLights && aodEnabled && mDozing && !mPulseLightHandled) {
+                if (activeNotif && ambientLights && mDozing && !mPulseLightHandled) {
                     // no-op if pulseLights is also enabled
                     if (ambientLightsHideAod) {
                         showAodContent(false);

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -414,6 +414,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
+import com.android.internal.util.custom.cutout.CutoutFullscreenController;
 
 public class ActivityManagerService extends IActivityManager.Stub
         implements Watchdog.Monitor, BatteryStatsImpl.BatteryCallback {
@@ -1683,6 +1684,8 @@ public class ActivityManagerService extends IActivityManager.Stub
     private GamingModeController mGamingModeController;
 
     private SystemSensorManager mSystemSensorManager;
+
+    private CutoutFullscreenController mCutoutFullscreenController;
 
     /**
      * Used to notify activity lifecycle events.
@@ -7930,6 +7933,9 @@ public class ActivityManagerService extends IActivityManager.Stub
         mGamingModeController = new GamingModeController(mContext);
 
         mSystemSensorManager = new SystemSensorManager(mContext, mHandler.getLooper());
+        
+        // Force full screen for devices with cutout
+        mCutoutFullscreenController = new CutoutFullscreenController(mContext);
     }
 
     void startPersistentApps(int matchFlags) {
@@ -20435,6 +20441,12 @@ public class ActivityManagerService extends IActivityManager.Stub
     public boolean isSwipeToScreenshotGestureActive() {
         synchronized (this) {
             return mIsSwipeToScrenshotEnabled && SystemProperties.getBoolean("sys.android.screenshot", false);
+        }
+    }
+        	@Override
+    public boolean shouldForceCutoutFullscreen(String packageName) {
+        synchronized (this) {
+            return mCutoutFullscreenController.shouldForceCutoutFullscreen(packageName);
         }
     }
 }

--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -1385,9 +1385,7 @@ public final class PowerManagerService extends SystemService
                 UserHandle.USER_CURRENT);
         boolean mAmbientLights = Settings.System.getIntForUser(resolver,
                 Settings.System.AOD_NOTIFICATION_PULSE, 0, UserHandle.USER_CURRENT) != 0;
-        boolean aodEnabled = Settings.Secure.getIntForUser(resolver,
-                Settings.Secure.DOZE_ALWAYS_ON, 0, UserHandle.USER_CURRENT) == 1;
-        if (mAmbientLights && aodEnabled) {
+        if (mAmbientLights) {
             boolean dozeOnNotification = Settings.System.getIntForUser(resolver,
                     Settings.System.AOD_NOTIFICATION_PULSE_TRIGGER, 0, UserHandle.USER_CURRENT) != 0;
             Settings.System.putIntForUser(resolver,


### PR DESCRIPTION
1. Added no cutout for notch devices!!!! Inspired by MIUI and Essential. you can play games without side image cropping.
 
2. Reverted "base: Only allow edge lights on AOD when AOD is enabled [1/2]"  
Wee need this commit because edge notification is awesome.... Lets decide the user to drain battery on non ambient device for min 5 minutes.. And we can turn it off if we want.